### PR TITLE
Set file to readonly, changed output extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 *.log
 *.txt
+*.jmq


### PR DESCRIPTION
Sets file permissions to readonly, refactors some flow and exercises using references to avoid losing fights with the borrow checker